### PR TITLE
Add levels of difficulty to evals

### DIFF
--- a/agents_mcp_usage/multi_mcp/mermaid_diagrams.py
+++ b/agents_mcp_usage/multi_mcp/mermaid_diagrams.py
@@ -63,7 +63,7 @@ graph LR
 ```
 """
 
-invalid_mermaid_diagram_easy = """
+invalid_mermaid_diagram_medium = """
 ```mermaid
 graph LR
     User((User)) --> |"Run script<br>(e.g., pydantic_mcp.py)"| Agent
@@ -127,7 +127,71 @@ graph LR
 ```
 """
 
-valid_mermaid_diagram = """
+invalid_mermaid_diagram_easy = """
+```mermaid
+graph LR
+    User((User)) --> |"Run script<br>(e.g., pydantic_mcp.py)"| Agent
+
+    %% Agent Frameworks
+    subgraph "Agent Frameworks"
+        direction TB
+        Agent[Agent]
+        ADK["Google ADK<br>(adk_mcp.py)"]
+        LG["LangGraph<br>(langgraph_mcp.py)"]
+        OAI["OpenAI Agents<br>(oai-agent_mcp.py)"]
+        PYD["Pydantic-AI<br>(pydantic_mcp.py)"]
+
+        Agent --> ADK
+        Agent --> LG
+        Agent --> OAI
+        Agent --> PYD
+    end
+
+    %% MCP Server
+    subgraph "MCP Server"
+        direction TB
+        MCP["Model Context Protocol Server<br>(run_server.py)"]
+        Tools["Tools<br>- add(a, b)<br>- get_current_time() e.g. {current_time}"]
+        Resources["Resources<br>- greeting://{{name}}"]
+        MCPs --- Tools
+        MCPs --- Resources
+    end
+
+    subgraph "LLM Providers"
+        OAI_LLM["OpenAI Models"]
+        GEM["Google Gemini Models"]
+        OTHER["Other LLM Providers..."]
+    end
+
+    Logfire[("Logfire<br>Tracing")]
+
+    ADK --> MCP
+    LG --> MCP
+    OAI --> MCP
+    PYD --> MCP
+
+    MCP --> OAI_LLM
+    MCP --> GEM
+    MCP --> OTHER
+
+    ADK --> Logfire
+    LG --> Logfire
+    OAI --> Logfire
+    PYD --> Logfire
+
+    LLM_Response[("Response")] --> User
+    OAI_LLM --> LLM_Response
+    GEM --> LLM_Response
+    OTHER --> LLM_Response
+
+    style MCP fill:#f9f,stroke:#333,stroke-width:2px
+    style User fill:#bbf,stroke:#338,stroke-width:2px
+    style Logfire fill:#bfb,stroke:#383,stroke-width:2px
+    style LLM_Response fill:#fbb,stroke:#833,stroke-width:2px
+```
+"""
+
+valid_mermaid_diagram = """`
 ```mermaid
 graph LR
     User((User)) --> |"Run script<br>(e.g., pydantic_mcp.py)"| Agent

--- a/mcp_servers/mermaid_validator.py
+++ b/mcp_servers/mermaid_validator.py
@@ -1,0 +1,256 @@
+import json
+import os
+import subprocess
+import tempfile
+import argparse
+import asyncio
+import sys
+import time
+from typing import Optional
+
+from loguru import logger
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+# Configure loguru
+logger.remove()  # Remove default handler
+logger.add(
+    sys.stderr,
+    format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+    level="DEBUG",
+)
+logger.add(
+    "mermaid_validator.log",
+    rotation="10 MB",
+    retention="1 week",
+    level="DEBUG",
+)
+
+# Add a file logger with more details for debugging
+logger.add(
+    "mermaid_raw_input.log",
+    format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level} | {message}",
+    level="DEBUG",
+    filter=lambda record: "raw_input" in record["extra"],
+    rotation="10 MB",
+)
+
+# Patch mcp.run to capture raw input
+original_run = FastMCP.run
+
+
+def patched_run(self, transport: str = "stdio", *args, **kwargs):
+    logger.info(f"Starting MCP server with transport: {transport}")
+
+    # Patch stdio handling if needed
+    if transport == "stdio":
+        # Store the original stdin.read
+        original_stdin_read = sys.stdin.read
+        original_stdin_readline = sys.stdin.readline
+
+        def patched_read(n=-1):
+            data = original_stdin_read(n)
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+            logger.bind(raw_input=True).debug(
+                f"[STDIN READ][{timestamp}] Length: {len(data)}, Data: {data}"
+            )
+            return data
+
+        def patched_readline(size=-1):
+            data = original_stdin_readline(size)
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+            logger.bind(raw_input=True).debug(
+                f"[STDIN READLINE][{timestamp}] Line: {data}"
+            )
+            return data
+
+        # Patch stdin.read
+        sys.stdin.read = patched_read
+        sys.stdin.readline = patched_readline
+
+    # Call the original run method
+    return original_run(self, transport, *args, **kwargs)
+
+
+# Apply the patch
+FastMCP.run = patched_run
+
+mcp = FastMCP("mermaid-validator")
+
+
+class MermaidValidationResult(BaseModel):
+    """Result of mermaid diagram validation."""
+
+    is_valid: bool = Field(description="Whether the mermaid diagram is valid")
+    error_message: Optional[str] = Field(
+        None, description="Error message if the diagram is invalid"
+    )
+
+
+@mcp.tool()
+async def validate_mermaid_diagram(diagram_text: str) -> MermaidValidationResult:
+    """Validate a mermaid diagram.
+
+    Uses mermaid-cli to validate an input string as a mermaid diagram.
+    Expects input to be mermaid syntax only, no wrapping code blocks or ```mermaid tags.
+
+    Args:
+        diagram_text: The mermaid diagram text to validate
+
+    Returns:
+        A MermaidValidationResult object containing validation results
+    """
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    logger.info(f"MCP tool called: validate_mermaid_diagram at {timestamp}")
+    logger.debug(f"Input diagram text (first 100 chars): {diagram_text[:100]}...")
+    # Log the full diagram text to the raw input log
+    logger.bind(raw_input=True).debug(
+        f"[TOOL CALL][{timestamp}] Full diagram text: {diagram_text}"
+    )
+
+    temp_file_path = None
+    puppeteer_config_path = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix=".mmd", mode="w", delete=False
+        ) as temp_file:
+            temp_file.write(diagram_text)
+            temp_file_path = temp_file.name
+            logger.debug(f"Created temporary file: {temp_file_path}")
+
+        puppeteer_config = {"args": ["--no-sandbox", "--disable-setuid-sandbox"]}
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as config_file:
+            json.dump(puppeteer_config, config_file)
+            puppeteer_config_path = config_file.name
+            logger.debug(f"Created puppeteer config file: {puppeteer_config_path}")
+
+        # Run mermaid-cli to validate input string as mermaid diagram
+        logger.debug("Running mermaid-cli validation...")
+        result = subprocess.run(
+            [
+                "npx",
+                "-y",
+                "@mermaid-js/mermaid-cli",
+                "-i",
+                temp_file_path,
+                "--puppeteerConfigFile",
+                puppeteer_config_path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            logger.info("Mermaid diagram validation successful")
+            return MermaidValidationResult(is_valid=True, error_message=None)
+        else:
+            logger.warning(f"Mermaid diagram validation failed: {result.stderr}")
+            logger.bind(raw_input=True).debug(
+                f"[VALIDATION ERROR][{timestamp}] {result.stderr}"
+            )
+            return MermaidValidationResult(
+                is_valid=False,
+                error_message=f"Mermaid diagram is invalid: {result.stderr}",
+            )
+    except Exception as e:
+        logger.error(f"Error validating mermaid diagram: {str(e)}")
+        logger.bind(raw_input=True).debug(f"[EXCEPTION][{timestamp}] {str(e)}")
+        return MermaidValidationResult(
+            is_valid=False,
+            error_message=f"Error validating mermaid diagram: {str(e)}",
+        )
+    finally:
+        for file_path in [temp_file_path, puppeteer_config_path]:
+            if file_path and os.path.exists(file_path):
+                try:
+                    os.unlink(file_path)
+                    logger.debug(f"Deleted temporary file: {file_path}")
+                except Exception as e:
+                    logger.error(f"Error deleting temporary file {file_path}: {e}")
+
+
+@mcp.resource("example://mermaid-diagram")
+def get_example_mermaid_diagram():
+    """Provides an example mermaid diagram for the client.
+
+    Returns:
+        Dict containing an example mermaid diagram
+    """
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    logger.info(f"Resource called: example://mermaid-diagram at {timestamp}")
+    logger.bind(raw_input=True).debug(
+        f"[RESOURCE CALL][{timestamp}] example://mermaid-diagram"
+    )
+    return """
+    ```mermaid
+    graph TD
+        A[Start] --> B{Is it valid?}
+        B -->|Yes| C[Output valid result]
+        B -->|No| D[Output error message]
+        C --> E[End]
+        D --> E
+    ```
+    """
+
+
+@mcp.prompt("validate-string-as-mermaid")
+def validate_string_as_mermaid(diagram_text: str) -> MermaidValidationResult:
+    """Validate a string as a mermaid diagram.
+
+    Uses mermaid-cli to validate an input string as a mermaid diagram.
+    Expects input to be mermaid syntax only, no wrapping code blocks or ```mermaid tags.
+    """
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    logger.info(f"Prompt called: validate-string-as-mermaid at {timestamp}")
+    logger.debug(f"Original input (first 100 chars): {diagram_text[:100]}...")
+    logger.bind(raw_input=True).debug(
+        f"[PROMPT CALL][{timestamp}] Original full input: {diagram_text}"
+    )
+
+    # Strip whitespace, remove backticks and ```mermaid markers
+    input_str = diagram_text.strip()
+
+    # Remove ```mermaid and ``` markers
+    if input_str.startswith("```mermaid"):
+        input_str = input_str[len("```mermaid") :].strip()
+        logger.debug("Removed ```mermaid prefix")
+    if input_str.endswith("```"):
+        input_str = input_str[:-3].strip()
+        logger.debug("Removed ``` suffix")
+
+    # Remove any remaining backticks
+    input_str = input_str.replace("`", "")
+
+    logger.debug(
+        f"Cleaned input for validation (first 100 chars): {input_str[:100]}..."
+    )
+    logger.bind(raw_input=True).debug(
+        f"[PROMPT CALL][{timestamp}] Cleaned full input: {input_str}"
+    )
+
+    # Validate the cleaned diagram
+    return validate_mermaid_diagram(input_str)
+
+
+if __name__ == "__main__":
+    logger.info("Starting mermaid-validator MCP server")
+    parser = argparse.ArgumentParser(description="Mermaid diagram validator")
+    parser.add_argument(
+        "--debug", action="store_true", help="Run validation on a placeholder diagram"
+    )
+    args = parser.parse_args()
+
+    if args.debug:
+        # Example diagram for debugging
+        logger.info("Running in debug mode with example diagram")
+        debug_diagram = get_example_mermaid_diagram()
+        # Run the validation function
+        result = asyncio.run(validate_string_as_mermaid(debug_diagram))
+        logger.info(f"Debug validation result: {result}")
+        print(f"Debug validation result: {result}")
+    else:
+        transport = os.getenv("MCP_TRANSPORT", "stdio")
+        mcp.run(transport=transport)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.9",
     "langgraph>=0.3.31",
     "logfire>=3.14.0",
+    "loguru>=0.7.3",
     "mcp==1.6.0",
     "openai-agents>=0.0.12",
     "pydantic-ai-slim[mcp]>=0.1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1065,6 +1065,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1531,6 +1544,7 @@ dependencies = [
     { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
     { name = "logfire" },
+    { name = "loguru" },
     { name = "mcp" },
     { name = "openai-agents" },
     { name = "pydantic-ai-slim", extra = ["mcp"] },
@@ -1549,6 +1563,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.0.9" },
     { name = "langgraph", specifier = ">=0.3.31" },
     { name = "logfire", specifier = ">=3.14.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", specifier = "==1.6.0" },
     { name = "openai-agents", specifier = ">=0.0.12" },
     { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=0.1.3" },
@@ -2017,6 +2032,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces structured levels of difficulty for mermaid diagram evaluation cases, expands and refines the evaluation logic, and adds a new standalone MCP server tool for mermaid diagram validation.

## Problem:

Previously, all mermaid diagram evaluation cases were at a single (implicit) difficulty level, and validation logic was embedded and tightly coupled in one place. This made it hard to test more nuanced LLM capabilities, extend evaluation coverage, or debug diagram validation issues. Additionally, mermaid validation was dependent on subprocess logic and lacked a dedicated, reusable server tool.

## Solution:

- Added explicit “easy”, “medium”, and “hard” levels for invalid mermaid diagram cases.
- Incorporated a new `mcp_servers/mermaid_validator.py` MCP server tool, leveraging `mermaid-cli` via npx and structured logging with loguru.
- Refactored evaluation code to use the new server tool, support more robust string cleaning, and improve logging.
- Updated dependencies in `pyproject.toml` and `uv.lock` to include `loguru` for advanced logging.
- Improved test case metadata and expanded the evaluation rubric.

## Unlocks:

- Enables targeted and incremental evaluation of LLMs’ ability to repair mermaid diagrams of varying complexity.
- Facilitates debugging and extension of mermaid diagram validation as a reusable, standalone service.
- Allows for richer analysis and troubleshooting with enhanced logging and separation of concerns.

### Detailed breakdown of changes:
Provide a detailed description of what you changed.

- **agents_mcp_usage/multi_mcp/eval_multi_mcp/evals_pydantic_mcp.py**
  - Refactored to add “easy”, “medium”, and “hard” difficulty levels for invalid diagram test cases.
  - Switched from subprocess-based validation to using the new MCP server’s validation tool.
  - Improved diagram string cleaning and validation logic.
  - Enhanced logging for evaluation steps.

- **agents_mcp_usage/multi_mcp/mermaid_diagrams.py**
  - Added new `invalid_mermaid_diagram_medium` definition.
  - Clarified and reordered diagram definitions.

- **mcp_servers/mermaid_validator.py** (new)
  - Implements an MCP server exposing mermaid diagram validation as a tool.
  - Uses `mermaid-cli` via `npx`, with robust cleanup, error handling, and loguru-based logging.
  - Includes both tool and prompt endpoints for validation, as well as a resource for an example diagram.

- **pyproject.toml** and **uv.lock**
  - Added `loguru` as a dependency for structured logging.
  - Updated lockfile to reflect new and updated dependencies.